### PR TITLE
[Firefly] Codification: aws_cloudwatch_log_group

### DIFF
--- a/infl-6376109f5ccf43b943fa38f2.tf
+++ b/infl-6376109f5ccf43b943fa38f2.tf
@@ -1,0 +1,18 @@
+resource "aws_cloudwatch_log_group" "awslambdahelm-provider-vpc-connector-932338e4f158d48a23e5256890516835-146" {
+  name = "/aws/lambda/helm-provider-vpc-connector-932338e4f158d48a23e5256890516835"
+}
+
+
+
+
+resource "aws_cloudwatch_log_group" "cloudformationregistryawsqs-kubernetes-helm-bcb" {
+  name = "/cloudformation/registry/awsqs-kubernetes-helm"
+}
+
+
+
+
+resource "aws_cloudwatch_log_group" "awslambdaawsqs-kubernetes-resource-proxy-TanzuCluster-83a" {
+  name = "/aws/lambda/awsqs-kubernetes-resource-proxy-TanzuCluster"
+}
+


### PR DESCRIPTION
## Firefly Codification

#### Firefly has created this PR to codify cloud resources.
[Review Recommended]
As this is a private repository, Firefly does not have access. Therefore, this PR has been created automatically, but appears to have been created by a real user.

#### Terraform Import
		terraform import aws_cloudwatch_log_group.awslambdahelm-provider-vpc-connector-932338e4f158d48a23e5256890516835-146 /aws/lambda/helm-provider-vpc-connector-932338e4f158d48a23e5256890516835
		terraform import aws_cloudwatch_log_group.cloudformationregistryawsqs-kubernetes-helm-bcb /cloudformation/registry/awsqs-kubernetes-helm
		terraform import aws_cloudwatch_log_group.awslambdaawsqs-kubernetes-resource-proxy-TanzuCluster-83a /aws/lambda/awsqs-kubernetes-resource-proxy-TanzuCluster
